### PR TITLE
Fix npm publish job for OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,10 +32,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+      # No registry-url here: it writes an .npmrc with _authToken=${NODE_AUTH_TOKEN},
+      # which yarn install fatally tries to expand. OIDC trusted publishing needs
+      # no auth config — npm publish targets registry.npmjs.org by default.
       - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
-          registry-url: https://registry.npmjs.org/
           cache: 'yarn'
       - name: Verify release tag matches package.json version
         run: |


### PR DESCRIPTION
The v1.0.0 release publish failed at `yarn install` in the publish job:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

`setup-node`'s `registry-url` input writes an `.npmrc` containing `_authToken=${NODE_AUTH_TOKEN}`. Since the token secret was removed in favor of OIDC trusted publishing, yarn 1 crashes expanding the undefined variable during install.

Fix: drop `registry-url` from the publish job. OIDC trusted publishing requires no auth entry in `.npmrc`, and `npm publish` targets registry.npmjs.org by default.

After merging, the v1.0.0 release and tag need to be re-created so the release workflow runs from a commit containing this fix (release workflows execute the workflow file at the tagged commit).