### PR TITLE
Add repository field required by npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
   ],
   "author": "Valeh Asadli",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/valehasadli/TypeWired.git"
+  },
   "bugs": {
     "url": "https://github.com/valehasadli/typewired/issues"
   },


### PR DESCRIPTION
The v1.0.0 publish got through OIDC auth and provenance signing, then npm rejected the upload:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
Failed to validate repository information: package.json: "repository.url" is "",
expected to match "https://github.com/valehasadli/TypeWired" from provenance
```

package.json had no `repository` field. Adds it with the exact repo URL (case-sensitive match against the provenance statement).

After merging: delete and re-create the v1.0.0 release/tag so the publish runs from a commit containing this field.